### PR TITLE
[FEAT]: 관리자 페이지 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 		implementation 'org.springframework.boot:spring-boot-starter-web'
 		implementation 'org.springframework.boot:spring-boot-starter-validation'
 		implementation 'com.fasterxml.jackson.core:jackson-databind'
+		implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 		compileOnly 'org.projectlombok:lombok'
 		runtimeOnly 'com.h2database:h2'
 		runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/jnu_ddobuk/fruitsfarm_BE/admin/AdminPageController.java
+++ b/src/main/java/jnu_ddobuk/fruitsfarm_BE/admin/AdminPageController.java
@@ -1,0 +1,41 @@
+package jnu_ddobuk.fruitsfarm_BE.admin;
+
+import jnu_ddobuk.fruitsfarm_BE.global.exception.CustomException;
+import jnu_ddobuk.fruitsfarm_BE.global.exception.ErrorCode;
+import jnu_ddobuk.fruitsfarm_BE.habittracker.entity.HabitTracker;
+import jnu_ddobuk.fruitsfarm_BE.habittracker.service.HabitTrackerService;
+import jnu_ddobuk.fruitsfarm_BE.member.entity.Member;
+import jnu_ddobuk.fruitsfarm_BE.member.repository.MemberRepository;
+import jnu_ddobuk.fruitsfarm_BE.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class AdminPageController {
+
+    private final MemberService memberService;
+    private final HabitTrackerService habitTrackerService;
+    private final MemberRepository memberRepository;
+
+    @GetMapping("/admin/dashboard")
+    public String showAdminDashboard(Model model) {
+        model.addAttribute("members", memberService.getAllMembers());
+        return "admin/dashboard";
+    }
+
+    @GetMapping("/admin/member/{memberId}")
+    public String showMemberDetails(@PathVariable Long memberId, Model model) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()->new CustomException(ErrorCode.NOT_FOUND_MEMBER));
+        List<HabitTracker> trackers = habitTrackerService.getHabitTrackersByMemberId(member.getId());
+        model.addAttribute("member", member);
+        model.addAttribute("trackers", trackers);
+        return "admin/member_detail";
+    }
+}

--- a/src/main/java/jnu_ddobuk/fruitsfarm_BE/global/config/WebConfig.java
+++ b/src/main/java/jnu_ddobuk/fruitsfarm_BE/global/config/WebConfig.java
@@ -1,5 +1,6 @@
 package jnu_ddobuk.fruitsfarm_BE.global.config;
 
+import jnu_ddobuk.fruitsfarm_BE.web.interceptor.AdminCheckInterceptor;
 import jnu_ddobuk.fruitsfarm_BE.web.interceptor.LoginCheckInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -22,6 +23,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
+        //모든 요청에 대해 먼저 실행
         registry.addInterceptor(new LoginCheckInterceptor())
                 .order(1) // 실행 순서 지정 (낮을수록 먼저 실행)
                 .addPathPatterns("/**") // 모든 요청에 대해 인터셉터 적용
@@ -34,6 +36,11 @@ public class WebConfig implements WebMvcConfigurer {
                         "/swagger-ui/**",
                         "/v3/api-docs/**");
         //인터셉터에서 제외
+
+        // /admin으로 시작하는 요청에만 동작
+        registry.addInterceptor(new AdminCheckInterceptor())
+                .order(2)
+                .addPathPatterns("/admin/**"); // 관리자 전용 경로
     }
 
 }

--- a/src/main/java/jnu_ddobuk/fruitsfarm_BE/global/response/CustomApiResponse.java
+++ b/src/main/java/jnu_ddobuk/fruitsfarm_BE/global/response/CustomApiResponse.java
@@ -10,8 +10,8 @@ import org.springframework.http.HttpStatus;
 public record CustomApiResponse<T>(
         @JsonProperty("status_code") int statusCode,  // 상태 코드
         boolean success, // 성공 여부
-        @Nullable T data, // 응답 데이터
-        @Nullable ExceptionDto error // 에러 정보
+        @Nullable T data, // 성공시 응답 데이터
+        @Nullable ExceptionDto error // 실패시 에러 데이터
 ) {
     // 성공 응답 생성
     public static <T> CustomApiResponse<T> ok(@Nullable T data) {

--- a/src/main/java/jnu_ddobuk/fruitsfarm_BE/habittracker/service/HabitTrackerService.java
+++ b/src/main/java/jnu_ddobuk/fruitsfarm_BE/habittracker/service/HabitTrackerService.java
@@ -120,4 +120,11 @@ public class HabitTrackerService {
         });
 
     }
+
+    @Transactional(readOnly = true)
+    public List<HabitTracker> getHabitTrackersByMemberId(Long memberId) {
+        return habitTrackerRepository.findByMemberId(memberId);
+    }
+
+
 }

--- a/src/main/java/jnu_ddobuk/fruitsfarm_BE/member/entity/Member.java
+++ b/src/main/java/jnu_ddobuk/fruitsfarm_BE/member/entity/Member.java
@@ -24,10 +24,15 @@ public class Member {
     @Column(nullable = false) // Salt 필드 추가
     private String salt;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
     public Member(String accountId, String password, String salt) {
         this.accountId = accountId;
         this.password = password;
         this.salt = salt;
+        this.role = Role.USER;
     }
 
 }

--- a/src/main/java/jnu_ddobuk/fruitsfarm_BE/member/entity/Role.java
+++ b/src/main/java/jnu_ddobuk/fruitsfarm_BE/member/entity/Role.java
@@ -1,0 +1,6 @@
+package jnu_ddobuk.fruitsfarm_BE.member.entity;
+
+public enum Role {
+    USER,
+    TEACHER
+}

--- a/src/main/java/jnu_ddobuk/fruitsfarm_BE/member/service/MemberService.java
+++ b/src/main/java/jnu_ddobuk/fruitsfarm_BE/member/service/MemberService.java
@@ -15,6 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @Transactional
@@ -81,5 +83,12 @@ public class MemberService {
         }
         session.invalidate();//세션 삭제
     }
+
+    public List<Member> getAllMembers() {
+        return memberRepository.findAll();
+    }
+
+
+
 
 }

--- a/src/main/java/jnu_ddobuk/fruitsfarm_BE/web/interceptor/AdminCheckInterceptor.java
+++ b/src/main/java/jnu_ddobuk/fruitsfarm_BE/web/interceptor/AdminCheckInterceptor.java
@@ -1,0 +1,36 @@
+package jnu_ddobuk.fruitsfarm_BE.web.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jnu_ddobuk.fruitsfarm_BE.global.constant.SessionConst;
+import jnu_ddobuk.fruitsfarm_BE.global.exception.CustomException;
+import jnu_ddobuk.fruitsfarm_BE.global.exception.ErrorCode;
+import jnu_ddobuk.fruitsfarm_BE.member.entity.Member;
+import jnu_ddobuk.fruitsfarm_BE.member.entity.Role;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class AdminCheckInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        if (CorsUtils.isPreFlightRequest(request)) {
+            return true;
+        }
+
+        HttpSession session = request.getSession(false);
+        Member loginMember = session != null ? (Member) session.getAttribute(SessionConst.LOGIN_MEMBER) : null;
+
+        if (loginMember == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        if (loginMember.getRole() != Role.TEACHER) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/jnu_ddobuk/fruitsfarm_BE/web/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/jnu_ddobuk/fruitsfarm_BE/web/interceptor/LoginCheckInterceptor.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpSession;
 import jnu_ddobuk.fruitsfarm_BE.global.constant.SessionConst;
 import jnu_ddobuk.fruitsfarm_BE.global.exception.CustomException;
 import jnu_ddobuk.fruitsfarm_BE.global.exception.ErrorCode;
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 public class LoginCheckInterceptor implements HandlerInterceptor {
@@ -13,7 +14,7 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
 
-        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+        if (CorsUtils.isPreFlightRequest(request)) {
             return true;
         }
 

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>관리자 대시보드</title>
+</head>
+<body>
+<h1>회원 목록</h1>
+<table border="1">
+    <thead>
+    <tr>
+        <th>닉네임</th>
+        <th>권한</th>
+        <th>상세보기</th> <!-- 버튼 컬럼 추가 -->
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="member : ${members}">
+        <td th:text="${member.accountId}">아이디</td>
+        <td th:text="${member.role}">권한</td>
+        <td>
+            <a th:href="@{/admin/member/{id}(id=${member.id})}">상세보기</a>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/admin/member_detail.html
+++ b/src/main/resources/templates/admin/member_detail.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>회원 상세 정보</title>
+    <meta charset="UTF-8">
+</head>
+<body>
+
+<h1>회원 상세 정보</h1>
+
+<div>
+    <p><strong>회원 ID:</strong> <span th:text="${member.id}"></span></p>
+    <p><strong>닉네임:</strong> <span th:text="${member.accountId}"></span></p>
+    <p><strong>권한:</strong> <span th:text="${member.role}"></span></p>
+</div>
+
+<hr/>
+
+<h2>해빗 트래커 목록</h2>
+
+<table border="1">
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>타입</th>
+        <th>동기</th>
+        <th>목표</th>
+        <th>시작일</th>
+        <th>종료일</th>
+        <th>진행도</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="tracker : ${trackers}">
+        <td th:text="${tracker.id}"></td>
+        <td th:text="${tracker.type}"></td>
+        <td th:text="${tracker.motivation}"></td>
+        <td th:text="${tracker.achievement}"></td>
+        <td th:text="${tracker.startDate}"></td>
+        <td th:text="${tracker.endDate}"></td>
+        <td th:text="${tracker.progress}"></td>
+    </tr>
+    </tbody>
+</table>
+
+<a th:href="@{/admin/dashboard}">← 돌아가기</a>
+
+</body>
+</html>


### PR DESCRIPTION
## 주의
- [x] 브랜치 방향 확인하셨나요? 

## 관련 이슈
- close #4

## PR 유형

- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## PR 내용

1. 관리자 권한 확인을 위한 role 필드 Member 엔티티에 추가 및 기본값 USER 설정

2. 관리자 페이지 접속 시 권한 검사하는 Interceptor 구현 및 /admin/** 경로에 등록

3. 관리자용 서버사이드 렌더링 페이지 템플릿 (Thymeleaf 등) 기본 레이아웃 생성

4. 전체 회원 목록 및 각 회원별 정보 상세 조회 화면 구현