### PR TITLE
[FEAT]: HabitTrackerListResponseDto에 D+1 과 같은 진행일 계산 필드 추가

### DIFF
--- a/src/main/java/jnu_ddobuk/fruitsfarm_BE/habittracker/dto/HabitTrackerDetailResponseDto.java
+++ b/src/main/java/jnu_ddobuk/fruitsfarm_BE/habittracker/dto/HabitTrackerDetailResponseDto.java
@@ -1,8 +1,10 @@
 package jnu_ddobuk.fruitsfarm_BE.habittracker.dto;
 
 import jnu_ddobuk.fruitsfarm_BE.habittracker.entity.HabitTracker;
+import org.springframework.cglib.core.Local;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 
 public record HabitTrackerDetailResponseDto(
         Long habitTrackerId,
@@ -11,9 +13,12 @@ public record HabitTrackerDetailResponseDto(
         String motivation,
         LocalDate startDate,
         LocalDate endDate,
-        String progress
+        String progress,
+        int currentDate
 ) {
     public static HabitTrackerDetailResponseDto fromEntity(HabitTracker habitTracker) {
+        int currentDate = calculateCurrentDate(habitTracker.getStartDate());
+
         return new HabitTrackerDetailResponseDto(
                 habitTracker.getId(),
                 habitTracker.getType(),
@@ -21,7 +26,15 @@ public record HabitTrackerDetailResponseDto(
                 habitTracker.getMotivation(),
                 habitTracker.getStartDate(),
                 habitTracker.getEndDate(),
-                habitTracker.getProgress()
+                habitTracker.getProgress(),
+                currentDate
         );
     }
+
+    private static int calculateCurrentDate(LocalDate startDate) {
+        LocalDate today = LocalDate.now();
+        long days = ChronoUnit.DAYS.between(startDate, today);
+        return (int)days + 1;
+    }
+
 }


### PR DESCRIPTION
## 주의
- [x] 브랜치 방향 확인하셨나요? :)

## 관련 이슈
- close #6

## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정aaa
- [ ] 파일 혹은 폴더 삭제

## PR 내용

### ✅ 목적
- 사용자가 현재 몇 일차인지 프론트에서 확인할 수 있도록 하기 위함
- DB 저장 없이 startDate 기준으로 오늘 날짜까지의 경과일을 계산하여 전달

### ✨ 작업 내역
- `HabitTrackerDetailResponseDto`에 `currentDate` 필드 추가
- 현재 날짜 기준 경과일을 계산하여 반환
- `ChronoUnit.DAYS.between()` 사용하여 일차 계산


