### PR TITLE
[FEAT]: 사라진 관리자 상세페이지 구현

### DIFF
--- a/src/main/resources/templates/admin/member_detail.html
+++ b/src/main/resources/templates/admin/member_detail.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>회원 상세 정보</title>
+    <meta charset="UTF-8">
+    <style>
+        body {
+            font-family: "Helvetica Neue", sans-serif;
+            background-color: #f9f9f9;
+            padding: 2rem;
+        }
+        .container {
+            max-width: 1000px;
+            margin: auto;
+            background: #fff;
+            padding: 2rem;
+            border-radius: 10px;
+            box-shadow: 0 0 10px rgba(0,0,0,0.07);
+        }
+        h1, h2 {
+            color: #333;
+        }
+        .member-info {
+            margin-bottom: 2rem;
+            padding: 1.5rem;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            background: #f6f6f6;
+        }
+        .member-info p {
+            margin: 0.5rem 0;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 2rem;
+            background: #fff;
+        }
+        thead {
+            background-color: #f0f0f0;
+        }
+        th, td {
+            padding: 0.75rem;
+            text-align: center;
+            border: 1px solid #ccc;
+        }
+        .progress-bar-container {
+            width: 100%;
+            height: 16px;
+            background: #eee;
+            border-radius: 4px;
+            overflow: hidden;
+        }
+        .progress-bar {
+            height: 100%;
+            background-color: #4caf50;
+            width: 0%;
+            transition: width 0.4s;
+        }
+        .back-button {
+            display: inline-block;
+            padding: 0.6rem 1rem;
+            background-color: #1976d2;
+            color: white;
+            text-decoration: none;
+            border-radius: 5px;
+        }
+        .back-button:hover {
+            background-color: #1565c0;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+
+    <h1>회원 상세 정보</h1>
+    <div class="member-info">
+        <p><strong>회원 ID:</strong> <span th:text="${member.id}"></span></p>
+        <p><strong>닉네임:</strong> <span th:text="${member.accountId}"></span></p>
+        <p><strong>권한:</strong> <span th:text="${member.role}"></span></p>
+    </div>
+
+    <h2>해빗 트래커 목록</h2>
+    <table>
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>타입</th>
+            <th>동기</th>
+            <th>목표</th>
+            <th>시작일</th>
+            <th>종료일</th>
+            <th>진행률</th>
+            <th>상태</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="dto : ${dtoList}">
+            <td th:text="${dto.id}"></td>
+            <td>
+                <span th:switch="${dto.type}">
+                    <img th:case="'grape'" th:src="@{/images/grape.png}" alt="grape" height="32"/>
+                    <img th:case="'watermelon'" th:src="@{/images/watermelon.png}" alt="watermelon" height="32"/>
+                </span>
+            </td>
+            <td th:text="${dto.motivation}"></td>
+            <td th:text="${dto.achievement}"></td>
+            <td th:text="${dto.startDate}"></td>
+            <td th:text="${dto.endDate}"></td>
+            <td>
+                <div class="progress-bar-container">
+                    <div class="progress-bar" th:style="'width:' + ${dto.progressRate} + '%'"></div>
+                </div>
+                <p>
+                    <span th:text="${dto.completedCount}">0</span> /
+                    <span th:text="${dto.total}">0</span>
+                    (<span th:text="${#numbers.formatDecimal(dto.progressRate, 0, 1)}">0.0</span>%)
+                </p>
+            </td>
+            <td th:text="${dto.isCompleted} ? '완료' : '진행중'"></td>
+        </tr>
+        </tbody>
+    </table>
+    <a th:href="@{/admin/dashboard}" class="back-button">← 돌아가기</a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 주의
- [x] 브랜치 방향 확인하셨나요? :)

## 관련 이슈
- close #10

## PR 내용
사라진 관리자 상세페이지 구현

<img width="1084" height="1117" alt="image" src="https://github.com/user-attachments/assets/a1a7d4ce-4685-4b12-98c4-c05b968b15db" />

